### PR TITLE
Ajout du domaine usmba.ac.ma pour FST Fès

### DIFF
--- a/usmba.txt
+++ b/usmba.txt
@@ -1,0 +1,2 @@
+Université Sidi Mohamed Ben Abdellah de Fès
+Faculté des sciences et techniques de Fès


### PR DESCRIPTION
Ajout du domaine usmba.ac.ma pour l’Université Sidi Mohamed Ben Abdellah de Fès (FST Fès)

🔗 Site web officiel : https://www.fst-usmba.ac.ma/

📧 Mail étudiant : ayoub.elmane@usmba.ac.ma

📄 Cursus informatique : https://www.fst-usmba.ac.ma/departement-informatique/

📸 Preuve adresse mail étudiante :
![Mail ](https://github.com/user-attachments/assets/24a758e7-a73c-4e2d-a0bb-3b252ea4420e)


Merci pour l’ajout !